### PR TITLE
Implement monthly trading summary

### DIFF
--- a/config.py
+++ b/config.py
@@ -24,3 +24,6 @@ MIRROR_ENABLED     = os.getenv("MIRROR_ENABLED", "false").lower() in ("1", "true
 MIRROR_B_API_KEY   = os.getenv("MIRROR_B_API_KEY")
 MIRROR_B_API_SECRET= os.getenv("MIRROR_B_API_SECRET")
 MIRROR_COEFFICIENT = float(os.getenv("MIRROR_COEFFICIENT", "1.0"))
+
+# Monthly summary
+MONTHLY_REPORT_ENABLED = os.getenv("MONTHLY_REPORT_ENABLED", "false").lower() in ("1", "true", "yes")

--- a/db.py
+++ b/db.py
@@ -156,3 +156,46 @@ def reset_pending():
             cur.execute("UPDATE public.positions SET pending=false WHERE exchange='binance';")
     except Exception as e:
         log.error("reset_pending: %s", e)
+
+def pg_insert_closed_trade(symbol: str, side: str, volume: float, pnl: float, closed_at=None):
+    """Записываем информацию о закрытой сделке."""
+    from datetime import datetime
+    if closed_at is None:
+        closed_at = datetime.utcnow()
+    try:
+        with pg_conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO public.closed_trades
+                       (symbol, position_side, volume, pnl, closed_at)
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                (symbol, side, volume, pnl, closed_at),
+            )
+    except Exception as e:
+        log.error("pg_insert_closed_trade: %s", e)
+
+def pg_get_closed_trades_for_month(year: int, month: int):
+    """Возвращает список закрытых сделок за указанный месяц."""
+    from datetime import datetime
+    if month == 12:
+        start = datetime(year, month, 1)
+        end = datetime(year + 1, 1, 1)
+    else:
+        start = datetime(year, month, 1)
+        end = datetime(year, month + 1, 1)
+    try:
+        with pg_conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT closed_at, symbol, position_side, volume, pnl
+                  FROM public.closed_trades
+                 WHERE closed_at >= %s AND closed_at < %s
+                 ORDER BY closed_at
+                """,
+                (start, end),
+            )
+            return cur.fetchall()
+    except Exception as e:
+        log.error("pg_get_closed_trades_for_month: %s", e)
+        return []


### PR DESCRIPTION
## Summary
- add MONTHLY_REPORT_ENABLED config option
- track closed trades in new `closed_trades` table
- implement monthly reporting in `AlexBot`
- ensure monthly report runs once on startup

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`