### PR TITLE
Add monthly summary reports on startup

### DIFF
--- a/config.py
+++ b/config.py
@@ -33,7 +33,17 @@ MIRROR_B_API_SECRET= os.getenv("MIRROR_B_API_SECRET")
 MIRROR_COEFFICIENT = float(os.getenv("MIRROR_COEFFICIENT", "1.0"))
 
 # ---- Опции ежемесячного отчёта ----
-MONTHLY_REPORT_ENABLED = os.getenv("MONTHLY_REPORT_ENABLED", "true").lower() in ("1", "true", "yes")
+MONTHLY_REPORT_ENABLED = os.getenv("MONTHLY_REPORT_ENABLED", "true").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+# Отправлять ли отчёты при запуске бота
+MONTHLY_REPORT_ON_START = os.getenv("MONTHLY_REPORT_ON_START", "false").lower() in (
+    "1",
+    "true",
+    "yes",
+)
 
 # ---- Через сколько дней очищать таблицу futures_events ----
 FUTURES_EVENTS_RETENTION_DAYS = int(os.getenv("FUTURES_EVENTS_RETENTION_DAYS", "60"))


### PR DESCRIPTION
## Summary
- add `MONTHLY_REPORT_ON_START` option
- send monthly report for previous month and current month on startup when enabled
- refactor monthly summary generation into helper function

## Testing
- `python -m py_compile alexbot.py config.py db.py telegram_bot.py main.py`