### PR TITLE
Fix PnL tracking when position is reopened

### DIFF
--- a/alexbot.py
+++ b/alexbot.py
@@ -947,7 +947,10 @@ class AlexBot:
                         f"at {self._fmt_price(sym, fill_price)}"
                     )
                     self.base_sizes[(sym, side)] = new_amt
-                    self.initial_sizes[(sym, side)] = self.initial_sizes.get((sym, side), old_amt) + fill_qty
+                    prev_initial = self.initial_sizes.get((sym, side), old_amt)
+                    # update the initial size to reflect the maximum open
+                    # volume observed for this position
+                    self.initial_sizes[(sym, side)] = max(prev_initial, new_amt)
 
                 # calculate new average entry price when position size increases
                 if new_amt > 1e-12 and old_amt > 1e-12:


### PR DESCRIPTION
## Summary
- ensure `initial_sizes` reflects the maximum open size

## Testing
- `python3 -m py_compile alexbot.py db.py config.py telegram_bot.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_688c7b4c6b6c83228aa32e87587207f2